### PR TITLE
Fixed unexpected panic with earlier error handling

### DIFF
--- a/router_agent.go
+++ b/router_agent.go
@@ -189,10 +189,16 @@ func (agent *RouterAgentChat) Chat(message string) error {
 
 	response, err := agent.client.FetchChatCompletions(request)
 
+	if err != nil {
+		// rollback user message
+		agent.Messages = agent.Messages[:len(agent.Messages)-1]
+		return err
+	}
+
 	agent.Messages = append(agent.Messages, MessageRequest{
 		Role:    RoleAssistant,
 		Content: response.Choices[0].Message.Content,
 	})
 
-	return err
+	return nil
 }


### PR DESCRIPTION
Existing code of agent `Chat` method may cause unexpected panic.
I accidentally came across that by using an incorrect openrouter token. In this case I got 401 (Unauthoreized) error from openrouter and `response` was `nil`, that led to a panic on the line 194, where we referred to `response`'s Choices field.

I think that expected behavior in this and other similar cases is to return error from `Chat` method, but not to panic.

Also in this case I consider we should rollback the last user message to keep chat history consistent, because there is no answer to that due to technical error.